### PR TITLE
Working with arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The solution is comprised of 100% Open Source software and meets all CloudNative
 ### Internal roles
 All internal roles are destined to become Ansible Galaxy roles...
 
-### Ansible galaxy rollen
+### Ansible galaxy rols
 All Ansible Galaxy roles are included as part of this repo, but:
 - if they have changes these will be upstreamed to the original Ansible Galaxy role
 - once all is upstreamed they will be replaced with references to the ansible galaxy roles instead.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+jinja2_extensions = jinja2.ext.do
+host_key_checking = False

--- a/functional-all.yml
+++ b/functional-all.yml
@@ -1,12 +1,16 @@
 ---
 - name: "Gather facts on all servers"
   hosts:
-    - all
+    - hacluster
+    - backup
+    - router
   become: true
   gather_facts: true
 
 - hosts:
-    - all
+    - hacluster
+    - backup
+    - router
   become: true
   gather_facts: false
   roles:
@@ -34,7 +38,7 @@
     - minio
 
 - hosts:
-    - stolon
+    - hacluster
   become: true
   gather_facts: false
   roles:

--- a/functional-all.yml
+++ b/functional-all.yml
@@ -42,6 +42,15 @@
   become: true
   gather_facts: false
   roles:
+    - walg
+  tags:
+    - walg
+
+- hosts:
+    - hacluster
+  become: true
+  gather_facts: false
+  roles:
     - stolon
   tags:
     - stolon
@@ -58,15 +67,6 @@
   tags:
     - avchecker
     - availability_checker
-
-- hosts:
-    - hacluster
-  become: true
-  gather_facts: false
-  roles:
-    - walg
-  tags:
-    - walg
 
 - hosts:
     - router

--- a/functional-all.yml
+++ b/functional-all.yml
@@ -20,6 +20,16 @@
     - linux
 
 - hosts:
+    - hacluster
+  become: true
+  gather_facts: false
+  roles:
+    - firewall
+  tags:
+    - firewall
+    - firewalld
+
+- hosts:
     - etcd_master
   become: true
   gather_facts: false

--- a/roles/avchecker/files/avchecker.py
+++ b/roles/avchecker/files/avchecker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import psycopg2
 import time

--- a/roles/avchecker/tasks/main.yml
+++ b/roles/avchecker/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
 # tasks file for avchecker
-- include_tasks: install.yml
-  when: avchecker_defaults | length > 0
-- include_tasks: configure.yml
-  when: avchecker_defaults | length > 0
-- include_tasks: certs.yml
-- include_tasks: postgres.yml
-- include_tasks: start.yml
+
+- name: Install and configure avchecker
+  block:
+    - include_tasks: install.yml
+    - include_tasks: configure.yml
+    - include_tasks: certs.yml
+    - include_tasks: postgres.yml
+    - include_tasks: start.yml
   when: avchecker_defaults | length > 0

--- a/roles/firewall/.travis.yml
+++ b/roles/firewall/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/firewall/README.md
+++ b/roles/firewall/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+This role will manage firewall rules for PgVillage systems
+
+Requirements
+------------
+
+This module uses modele ansible.posix.firewalld
+
+Role Variables
+--------------
+
+All variables have sane defaults in defaults/main.yml so we would strongly recommend to refer there for all variables that can be set and documentation on what they can be used for
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - pgvillage.firewall
+
+License
+-------
+
+GPL-2.0-or-later
+
+Author Information
+------------------
+
+Please refer to https://www.pgvillage.com/ for more information on PgVillage.

--- a/roles/firewall/defaults/main.yml
+++ b/roles/firewall/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# defaults file for firewall
+firewall_type: external
+#Options:
+#- firewalld (manage firewalld firewall
+#- leave to cloud, don;t manage server firewall
+#We could extend to firewall on debian/ubuntu, iptables, whatever, but for now this is fine
+
+firewall_local_segment: "{{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ipaddr('network/prefix') }}"
+
+firewall_ports:
+  postgres: 5432
+  stolon_proxy: 25432
+  etcd_client: 2379
+  etcd_server: 2380

--- a/roles/firewall/handlers/main.yml
+++ b/roles/firewall/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for firewall

--- a/roles/firewall/meta/main.yml
+++ b/roles/firewall/meta/main.yml
@@ -1,0 +1,45 @@
+galaxy_info:
+  author: Sebastiaan Mannem
+  description: SOlutions Architect
+  company: Mannem Solutions
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  license: GPL-2.0-or-later
+
+  min_ansible_version: 2.1
+
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags:
+    - firewall
+    - firewalld
+    - pgvillage
+
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/firewall/tasks/firewalld.yml
+++ b/roles/firewall/tasks/firewalld.yml
@@ -1,0 +1,23 @@
+---
+- name: Install firewalld packages when defined
+  become: "true"
+  yum:
+    name: firewalld
+    state: present
+
+- name: Start firewalld systemd services
+  become: "true"
+  systemd:
+    name: "firewalld.service"
+    state: started
+    enabled: "true"
+
+- name: permit traffic is required
+  ansible.posix.firewalld:
+    port: '{{ item.value }}/tcp'
+    permanent: yes
+    immediate: yes
+    state: enabled 
+  loop: '{{ firewall_ports | dict2items }}'
+  loop_control:
+    label: "{{ item.key }}"

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# tasks file for firewall
+- include_tasks: "firewalld.yml"
+  when:
+    - "firewall_type == 'firewalld'" 

--- a/roles/firewall/tests/inventory
+++ b/roles/firewall/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/firewall/tests/test.yml
+++ b/roles/firewall/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - firewall

--- a/roles/firewall/vars/main.yml
+++ b/roles/firewall/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for firewall

--- a/roles/linux/defaults/main.yml
+++ b/roles/linux/defaults/main.yml
@@ -31,7 +31,7 @@ linux_packages:
 linux_public_repos:
   PgVillage:
     description: PgVillage RPM Library
-    baseurl: https://repo.mannemsolutions.nl/yum/pgvillage/
+    baseurl: https://repo.mannemsolutions.nl/yum/pgvillage/redhat/$basearch
     gpgkey: https://repo.mannemsolutions.nl/yum/pgvillage/gpg_pubkey.asc
     gpgcheck: yes
   "pgdg-common":

--- a/roles/linux/defaults/main.yml
+++ b/roles/linux/defaults/main.yml
@@ -5,18 +5,18 @@ linux_pg_version: "12"
 
 # You can define what RH products should be enabled for a group of servers
 # the custom filter (see filter_plugins/core.py) will convert this hash into a list of products only applying to that group
-linux_rhsm_poolids:
-  postgres:
-    # Postgresql12_8Server
-    - "0360c0e471df0ab20171f34552980362"
-    # rhel_misc
-    - "0360c0e47b1a20e9017b81870656140a"
-  backup:
-    # rhel_misc
-    - "0360c0e47b1a20e9017b81870656140a"
+linux_rhsm_poolids: {}
+#  postgres:
+#    # Postgresql12_8Server
+#    - "0360c0e471df0ab20171f34552980362"
+#    # rhel_misc
+#    - "0360c0e47b1a20e9017b81870656140a"
+#  backup:
+#    # rhel_misc
+#    - "0360c0e47b1a20e9017b81870656140a"
 
 linux_packages:
-  postgres:
+  hacluster:
     - "postgresql{{ linux_pg_version|replace('.','') }}"
     - "postgresql{{ linux_pg_version|replace('.','') }}-server"
     - "postgresql{{ linux_pg_version|replace('.','') }}-contrib"
@@ -28,18 +28,55 @@ linux_packages:
   backup:
     - "minio"
 
+linux_public_repos:
+  PgVillage:
+    description: PgVillage RPM Library
+    baseurl: https://repo.mannemsolutions.nl/yum/pgvillage/
+    gpgkey: https://repo.mannemsolutions.nl/yum/pgvillage/gpg_pubkey.asc
+    gpgcheck: yes
+  "pgdg-common":
+    description: PostgreSQL common RPMs for RHEL / Rocky $releasever - $basearch
+    baseurl: https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-$releasever-$basearch
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    repo_gpgcheck: yes
+    file: "pgdg-redhat-all"
+  "pgdg-rhel8-extras":
+    description: Extra packages to support some RPMs in the PostgreSQL RPM repo RHEL / Rocky $releasever - $basearch
+    baseurl: https://download.postgresql.org/pub/repos/yum/common/pgdg-rhel$releasever-extras/redhat/rhel-$releasever-$basearch
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    repo_gpgcheck: yes
+    file: "pgdg-redhat-all"
+  "pgdg{{ linux_pg_version }}":
+    description: "PostgreSQL {{ linux_pg_version }} for RHEL / Rocky $releasever - $basearch"
+    baseurl: "https://download.postgresql.org/pub/repos/yum/{{ linux_pg_version }}/redhat/rhel-$releasever-$basearch"
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    repo_gpgcheck: yes
+    file: "pgdg-redhat-all"
+
 linux_packages_gpg_check: "false"
 
+linux_rh_subscription: {}
+#  activationkey: "ORG1"
+#  org_id: "ORG1"
+#  pool_ids: "{}"
+#  state: present
+
 # repository rhel_misc
-rhel_misc_repo:
-  name: "Rhel_Misc"
-  description: "Rhel Misc repository"
-  baseurl: "http://satellite.example.org/pulp/content/ORG1/Library/custom/rhel_misc/rhel_misc/"
-  enabled: "true"
-  gpgcheck: "true"
-  gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-  sslverify: "true"
-  sslcacert: /etc/rhsm/ca/katello-server-ca.pem
-  sslclientkey: /etc/pki/entitlement/8675925567367701300-key.pem
-  sslclientcert: /etc/pki/entitlement/8675925567367701300.pem
-  priority: "20"
+linux_rh_misc_repo: {}
+#  name: "Rhel_Misc"
+#  description: "Rhel Misc repository"
+#  baseurl: "http://satellite.example.org/pulp/content/ORG1/Library/custom/rhel_misc/rhel_misc/"
+#  enabled: "true"
+#  gpgcheck: "true"
+#  gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+#  sslverify: "true"
+#  sslcacert: /etc/rhsm/ca/katello-server-ca.pem
+#  sslclientkey: /etc/pki/entitlement/8675925567367701300-key.pem
+#  sslclientcert: /etc/pki/entitlement/8675925567367701300.pem
+#  priority: "20"

--- a/roles/linux/defaults/main.yml
+++ b/roles/linux/defaults/main.yml
@@ -29,37 +29,46 @@ linux_packages:
     - "minio"
 
 linux_public_repos:
-  PgVillage:
+- key: PgVillage
+  value:
     description: PgVillage RPM Library
     baseurl: https://repo.mannemsolutions.nl/yum/pgvillage/redhat/$basearch
     gpgkey: https://repo.mannemsolutions.nl/yum/pgvillage/gpg_pubkey.asc
     gpgcheck: yes
-  "pgdg-common":
+- key: "pgdg-common"
+  value:
     description: PostgreSQL common RPMs for RHEL / Rocky $releasever - $basearch
     baseurl: https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-$releasever-$basearch
     enabled: yes
     gpgcheck: yes
-    gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    gpgkey: "{{ linux_pgdg_gpg_key[ansible_architecture] }}"
     repo_gpgcheck: yes
     file: "pgdg-redhat-all"
-  "pgdg-rhel8-extras":
+    exclude: etcd
+- key: "pgdg-rhel8-extras"
+  value:
     description: Extra packages to support some RPMs in the PostgreSQL RPM repo RHEL / Rocky $releasever - $basearch
     baseurl: https://download.postgresql.org/pub/repos/yum/common/pgdg-rhel$releasever-extras/redhat/rhel-$releasever-$basearch
     enabled: yes
     gpgcheck: yes
-    gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    gpgkey: "{{ linux_pgdg_gpg_key[ansible_architecture] }}"
     repo_gpgcheck: yes
     file: "pgdg-redhat-all"
-  "pgdg{{ linux_pg_version }}":
+- key: "pgdg{{ linux_pg_version }}"
+  value:
     description: "PostgreSQL {{ linux_pg_version }} for RHEL / Rocky $releasever - $basearch"
     baseurl: "https://download.postgresql.org/pub/repos/yum/{{ linux_pg_version }}/redhat/rhel-$releasever-$basearch"
     enabled: yes
-    gpgcheck: yes
-    gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    gpgcheck: '{% if ansible_architecture == "aarch64" %}no{% else %}yes{% endif %}'
+    gpgkey: "{{ linux_pgdg_gpg_key[ansible_architecture] }}"
     repo_gpgcheck: yes
     file: "pgdg-redhat-all"
 
-linux_packages_gpg_check: "false"
+linux_disable_gpg_check: "false"
+
+linux_pgdg_gpg_key:
+  x86_64: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+  aarch64: "https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-AARCH64-RHEL$releasever"
 
 linux_rh_subscription: {}
 #  activationkey: "ORG1"

--- a/roles/linux/tasks/packages.yml
+++ b/roles/linux/tasks/packages.yml
@@ -36,12 +36,13 @@
     gpgkey: "{{ item.value.gpgkey }}"
     gpgcheck: "{{ item.value.gpgcheck | default('no') }}"
     file: "{{ item.value.file | default(item.key) }}"
-  loop: "{{ linux_public_repos | dict2items }}"
+    exclude: "{{ item.value.exclude | default(omit) }}"
+  loop: "{{ linux_public_repos }}"
 
 - name: Disable postgresql module
   shell: "dnf module list | grep -q postgres && dnf module disable -y postgresql || echo No postgres module"
   args:
-    # Running dnf command instead of asnible dnf module on purpose here
+    # Running dnf command instead of ansible dnf module on purpose here
     warn: false
 
 - name: Install packages
@@ -49,5 +50,5 @@
     name: "{{ item }}"
     state: present
     update_cache: "true"
-    disable_gpg_check: "{{ linux_packages_gpg_check }}"
+    disable_gpg_check: "{{ linux_disable_gpg_check }}"
   loop: "{{ linux_packages|bygroup(group_names) }}"

--- a/roles/linux/tasks/packages.yml
+++ b/roles/linux/tasks/packages.yml
@@ -1,30 +1,42 @@
 ---
-- name: Enable the Postgresql RHSM subscriptions
-  redhat_subscription:
-    activationkey: "ORG1"
-    org_id: "ORG1"
-    pool_ids: "{{packages_rhsm_poolids|bygroup(group_names)}}"
-    state: present
+- name: Red Hat Satellite configuration
+  block:
+    - name: Enable the Postgresql RHSM subscriptions
+      redhat_subscription:
+        activationkey: "{{ linux_rh_subscription.activationkey }}"
+        org_id: "{{ linux_rh_subscription.org_id }}"
+        pool_ids: "{{ linux_rh_subscription.pool_ids }}"
+        state: present
 
-- name: enable rhel_misc repo
-  yum_repository: 
-    name: "{{ rhel_misc_repo.name }}"
-    description: "{{ rhel_misc_repo.description }}"
-    baseurl: "{{ rhel_misc_repo.baseurl }}"
-    enabled: "{{ rhel_misc_repo.enabled }}"
-    gpgcheck: "{{ rhel_misc_repo.gpgcheck }}"
-    gpgkey: "{{ rhel_misc_repo.gpgkey }}"
-    sslverify: "{{ rhel_misc_repo.sslverify }}"
-    sslcacert: "{{ rhel_misc_repo.sslcacert }}"
-    sslclientkey: "{{ rhel_misc_repo.sslclientkey }}"
-    sslclientcert: "{{ rhel_misc_repo.sslclientcert }}"
-    priority: "{{ rhel_misc_repo.priority }}"
+    - name: enable rhel_misc repo
+      yum_repository:
+        name: "{{ linux_rh_misc_repo.name }}"
+        description: "{{ linux_rh_misc_repo.description }}"
+        baseurl: "{{ linux_rh_misc_repo.baseurl }}"
+        enabled: "{{ linux_rh_misc_repo.enabled }}"
+        gpgcheck: "{{ linux_rh_misc_repo.gpgcheck }}"
+        gpgkey: "{{ linux_rh_misc_repo.gpgkey }}"
+        sslverify: "{{ linux_rh_misc_repo.sslverify }}"
+        sslcacert: "{{ linux_rh_misc_repo.sslcacert }}"
+        sslclientkey: "{{ linux_rh_misc_repo.sslclientkey }}"
+        sslclientcert: "{{ linux_rh_misc_repo.sslclientcert }}"
+        priority: "{{ linux_rh_misc_repo.priority }}"
+      when: "{{ linux_rh_misc_repo }}"
+    - name: autoattach
+      shell: "subscription-manager auto-attach"
+    - name: attach
+      shell: "subscription-manager attach"
+  when: "linux_rh_subscription"
 
-- name: autoattach
-  shell: "subscription-manager auto-attach"
-
-- name: attach
-  shell: "subscription-manager attach"
+- name: Add repository
+  ansible.builtin.yum_repository:
+    name: "{{ item.key }}"
+    description: "{{ item.value.description }}"
+    baseurl: "{{ item.value.baseurl }}"
+    gpgkey: "{{ item.value.gpgkey }}"
+    gpgcheck: "{{ item.value.gpgcheck | default('no') }}"
+    file: "{{ item.value.file | default(item.key) }}"
+  loop: "{{ linux_public_repos | dict2items }}"
 
 - name: Disable postgresql module
   shell: "dnf module disable -y postgresql"
@@ -34,7 +46,8 @@
 
 - name: Install packages
   dnf:
-    name: "{{ linux_packages|bygroup(group_names) }}"
+    name: "{{ item }}"
     state: present
     update_cache: "true"
     disable_gpg_check: "{{ linux_packages_gpg_check }}"
+  loop: "{{ linux_packages|bygroup(group_names) }}"

--- a/roles/linux/tasks/packages.yml
+++ b/roles/linux/tasks/packages.yml
@@ -39,7 +39,7 @@
   loop: "{{ linux_public_repos | dict2items }}"
 
 - name: Disable postgresql module
-  shell: "dnf module disable -y postgresql"
+  shell: "dnf module list | grep -q postgres && dnf module disable -y postgresql || echo No postgres module"
   args:
     # Running dnf command instead of asnible dnf module on purpose here
     warn: false

--- a/roles/nagios/defaults/main.yml
+++ b/roles/nagios/defaults/main.yml
@@ -27,16 +27,15 @@ nagios_connections_critical: "{{ nagios_connections_value|percent(80) }}"
 nagios_pg_version: 14
 
 nagios_wal_dir_mp: "/"
+nagios_wal_dir_mp_size: "{{ wal_dir_mp_size.stdout_lines[0] }}"
 nagios_max_wal_size_warning_percent: 65
 nagios_max_wal_size_critical_percent: 75
-nagios_wal_files_value: "{{ facter_mountpoints[nagios_wal_dir_mp]['size_bytes']|int / 16777216 }}"
+nagios_wal_files_value: "{{ nagios_wal_dir_mp_size|int / 16777216 }}"
 nagios_wal_files_warning: "{{ nagios_wal_files_value|percent(nagios_max_wal_size_warning_percent, 10) }}"
 nagios_wal_files_critical: "{{ nagios_wal_files_value|percent(nagios_max_wal_size_critical_percent, 100) }}"
 
 nagios_data_dir_mp: "/"
-nagios_data_dir_mp_size: "{{ facter_mountpoints[nagios_data_dir_mp]['size_bytes']|int }}"
-
-nagios_db_size_value: "{{ nagios_data_dir_mp_size }}"
+nagios_db_size_value: "{{ data_dir_mp_size.stdout_lines[0] }}"
 nagios_db_size_warning: "{{ nagios_db_size_value|percent(80)|human }}"
 nagios_db_size_critical: "{{ nagios_db_size_value|percent(90)|human }}"
 

--- a/roles/nagios/tasks/postgres.yml
+++ b/roles/nagios/tasks/postgres.yml
@@ -19,6 +19,20 @@
       - check_postgres
     state: present
 
+- name: get size of data dir in bytes
+  shell:
+    cmd: "df -B1 . | awk '{if(NR==2){print $4}}'"
+  args:
+    chdir: "{{ nagios_data_dir_mp }}"
+  register: data_dir_mp_size
+
+- name: get size of WAL dir in bytes
+  shell:
+    cmd: "df -B1 . | awk '{if(NR==2){print $4}}'"
+  args:
+    chdir: "{{ nagios_wal_dir_mp }}"
+  register: wal_dir_mp_size
+
 - name: create custom script folder
   file:
     path: "{{ nagios_scripts_folder }}"
@@ -52,7 +66,7 @@
 # Stolon has these named pipes in /tmp
 # NRPE by default has PrivateTmp=true, and thus cannot connect to postgres on /tmp/.s.PGSQL.5432
 # So, set PrivateTmp=false for this to work
-- name: Crate nrpe override folder
+- name: Create nrpe override folder
   file:
     dest: /etc/systemd/system/nrpe.service.d
     state: directory

--- a/roles/stolon/defaults/main.yml
+++ b/roles/stolon/defaults/main.yml
@@ -56,7 +56,8 @@ stolon_pg_su_connection_type: hostssl
 
 
 stolon_cluster_name: stolon-cluster
-stolon_cluster_hosts: "{{ groups.stolon }}"
+stolon_cluster_hosts: "{% for host in groups.stolon %}{{ hostvars[host]['ansible_fqdn'] }}{% if not loop.last %},{% endif %}{% endfor %}"
+
 stolon_store_backend: etcdv3
 stolon_proxy_port: 25432
 stolon_data_dir: "/var/lib/pgsql/{{ stolon_pg_version }}/data"
@@ -90,7 +91,7 @@ stolon_share_buffers_mb: "{{ [ ( stolon_available_memory_mb|int * stolon_shared_
 stolon_effective_cache_size_mb: "{{ [ ( stolon_available_memory_mb|int * stolon_eff_cache_ratio) | int, 1] | max }}"
 stolon_wal_dir_size: "{{ wal_dir_size.stdout_lines[0] }}"
 stolon_min_wal_size_mb: "{{ [ ( stolon_wal_dir_size|int * stolon_min_wal_size_ratio / 1048576) | int, 80] | max }}"
-stolon_max_wal_size_mb: "{{ ( stolon_wal_dir_size|int * stolon_max_wal_size_ratio / 1048576) | int, 1024 }}"
+stolon_max_wal_size_mb: "{{ [ ( stolon_wal_dir_size|int * stolon_max_wal_size_ratio / 1048576) | int, 1024 ] | max }}"
 stolon_max_worker_processes: "{{ [ansible_processor_vcpus|int * stolon_workers_ratio|int, 8] | max }}"
 stolon_max_parallel_workers: "{{ [ansible_processor_vcpus|int * stolon_parallel_ratio|int, 8] | max }}"
 stolon_max_parallel_workers_per_gather: "{{ [ansible_processor_vcpus|int * stolon_gather_ratio|int, 2] | max }}"

--- a/roles/stolon/defaults/main.yml
+++ b/roles/stolon/defaults/main.yml
@@ -66,9 +66,6 @@ stolon_wal_dir: "{{ stolon_pg_datadir }}/pg_wal"
 stolon_proxy_listen_address: "{{ ansible_default_ipv4.address }}"
 stolon_uid: "{{ inventory_hostname_short | replace('-', '_') }}"
 
-# Used to automatically size min_wal_size
-stolon_wal_dir_mp: "/var"
-
 # Used for automatically setting work_mem
 # Set to 1 for transactional, and 4-16 for analytical
 # Consider the averga amount of operations (merge, sort, group, etc.) per query
@@ -91,8 +88,9 @@ stolon_gather_ratio: 1
 # Autoconfig calculations
 stolon_share_buffers_mb: "{{ [ ( stolon_available_memory_mb|int * stolon_shared_buffers_ratio) | int, 8] | max }}"
 stolon_effective_cache_size_mb: "{{ [ ( stolon_available_memory_mb|int * stolon_eff_cache_ratio) | int, 1] | max }}"
-stolon_min_wal_size_mb: "{{ [ ( facter_mountpoints[stolon_wal_dir_mp]['size_bytes']|int * stolon_min_wal_size_ratio / 1048576) | int, 80] | max }}"
-stolon_max_wal_size_mb: "{{ [ ( facter_mountpoints[stolon_wal_dir_mp]['size_bytes']|int * stolon_max_wal_size_ratio / 1048576) | int, 1024] | max }}"
+stolon_wal_dir_size: "{{ wal_dir_size.stdout_lines[0] }}"
+stolon_min_wal_size_mb: "{{ [ ( stolon_wal_dir_size|int * stolon_min_wal_size_ratio / 1048576) | int, 80] | max }}"
+stolon_max_wal_size_mb: "{{ ( stolon_wal_dir_size|int * stolon_max_wal_size_ratio / 1048576) | int, 1024 }}"
 stolon_max_worker_processes: "{{ [ansible_processor_vcpus|int * stolon_workers_ratio|int, 8] | max }}"
 stolon_max_parallel_workers: "{{ [ansible_processor_vcpus|int * stolon_parallel_ratio|int, 8] | max }}"
 stolon_max_parallel_workers_per_gather: "{{ [ansible_processor_vcpus|int * stolon_gather_ratio|int, 2] | max }}"

--- a/roles/stolon/defaults/main.yml
+++ b/roles/stolon/defaults/main.yml
@@ -8,7 +8,8 @@ stolon_binary_owner: root
 stolon_pkg_arch: amd64
 stolon_bin_path: "{{ stolon_release_path }}/stolon-{{ stolon_release }}-linux-{{ stolon_pkg_arch }}/bin"
 # If you add items to stolon_packages, the binaries will not be downloaded, but installed from package instead
-stolon_package_names: []
+stolon_package_names:
+  - stolon
 #  - "stolon-keeper"
 #  - "stolon-proxy"
 #  - "stolon-sentinel"

--- a/roles/stolon/tasks/certs.yml
+++ b/roles/stolon/tasks/certs.yml
@@ -17,15 +17,3 @@
   loop: "{{ stolon_cert_files | dict2items }}"
   loop_control:
     label: "{{ item.key }} -> {{ item.value.path }}"
-
-- name: Update cluster spec
-  become: "true"
-  become_user: "{{ stolon_user }}"
-  shell:
-    cmd: '/usr/local/bin/stolonctl update --patch --file "${STOLONCTL_FILE}"'
-  environment:
-    STOLONCTL_CLUSTER_NAME: "{{ stolon_cluster_name }}"
-    STOLONCTL_STORE_BACKEND: "{{ stolon_store_backend }}"
-    STOLONCTL_FILE: "{{ stolon_custom_config_file }}"
-  throttle: 1
-

--- a/roles/stolon/tasks/install.yml
+++ b/roles/stolon/tasks/install.yml
@@ -5,6 +5,7 @@
     msg: "Can't install stolon: unsupported arch ({{ ansible_architecture }})."
   when:
     - ansible_architecture != "x86_64"
+    - stolon_package_names|length == 0
 
 - name: create stolon folders
   become: "true"

--- a/roles/stolon/tasks/main.yml
+++ b/roles/stolon/tasks/main.yml
@@ -26,6 +26,14 @@
     split: ":"
 
 - include_tasks: install.yml
+
+- name: get size of wal dir in bytes
+  shell:
+    cmd: "df -B1 . | awk '{if(NR==2){print $4}}'"
+  args:
+    chdir: "{{ stolon_wal_dir }}"
+  register: wal_dir_size
+
 - include_tasks: configure.yml
 - include_tasks: certs.yml
 - include_tasks: pglogging.yml

--- a/roles/stolon/templates/pg_service.conf.j2
+++ b/roles/stolon/templates/pg_service.conf.j2
@@ -8,7 +8,7 @@ port={{ stolon_proxy_port }}
 sslmode=verify-full
 
 [master]
-host={{ stolon_cluster_hosts | join(',') }}
+host={{ stolon_cluster_hosts }}
 port={{ stolon_pg_port }}
 target_session_attrs=read-write
 sslmode=verify-full

--- a/roles/wal_g/handlers/main.yml
+++ b/roles/wal_g/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for wal-g

--- a/roles/walg/defaults/main.yml
+++ b/roles/walg/defaults/main.yml
@@ -10,7 +10,8 @@ walg_distribution: "wal-g-pg-ubuntu-18.04"
 walg_exe_name: "{{ walg_distribution }}-{{ walg_pkg_arch }}"
 walg_exe_url: "https://github.com/wal-g/wal-g/releases/download/v{{ walg_release }}/{{walg_exe_name}}"
 # If you add items to walg_packages, the binary will not be downloaded, but installed from packages instead
-walg_packages: []
+walg_packages:
+  - wal-g-pg
 
 # wal-g scheduling with cron
 walg_cron_minute: "0"

--- a/roles/walg/tasks/install.yml
+++ b/roles/walg/tasks/install.yml
@@ -5,7 +5,8 @@
     msg: "Can't install wal-g: unsupported arch ({{ ansible_architecture }})."
   when:
     - ansible_architecture != "x86_64"
-    - walg_packages|length = 0
+    - ansible_architecture != "aarch64"
+    - walg_packages|length == 0
 
 - name: create wal-g folder
   become: "true"


### PR DESCRIPTION
- First commit on PgVillage
- Fixing disable module when not existing (e.a. rocky 9)
- Fixing many issues with stolon role defaults
- walg before stolon, so that restore_command can when when initing the other cluster nodes
- Fixes #12: remove leftover roles/wal_g/handlers/main.yml
- Remove redundant `Update cluster spec`
- Typo in README, and specify python3 for avchecker script
- New location for rpms
- Adding firewall role
- Many small optimizations in linux role
- By default install packages, and also allow for aarch64
