### PR TITLE
fix: Long time issue with dnf resolved

### DIFF
--- a/roles/linux/tasks/packages.yml
+++ b/roles/linux/tasks/packages.yml
@@ -39,14 +39,14 @@
     exclude: "{{ item.value.exclude | default(omit) }}"
   loop: "{{ linux_public_repos }}"
 
+# This should be dnf package, but it hangs
 - name: Upgrade all packages
   ansible.builtin.dnf:
     name: "*"
     state: latest
-  retries: 60
-  delay: 1
+  async: 600
+  poll: 5
   register: upgrade
-  until: upgrade.rc == 0
 
 - name: Disable postgresql module
   shell: "dnf module list | grep -q postgres && dnf module disable -y postgresql || echo No postgres module"


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When you run pgvillage, usually it hangs forever.
This might be a firewall issue which closes connections when there is no communication for too long.
Which might be caused by dnf taking long.

## What is the new behavior?

We nog run dnf as a sync job with a timeout of 10 minutes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


