### PR TITLE
fix: Issue with name of primary key

### DIFF
--- a/roles/chainsmith/defaults/main.yml
+++ b/roles/chainsmith/defaults/main.yml
@@ -53,7 +53,7 @@ chainsmith_users:
 #chainsmith_client_pkey_filename: 'client.key'
 chainsmith_client_cert_sub_folder: '.postgresql'
 chainsmith_client_cert_filename: 'postgresql.crt'
-chainsmith_client_pkey_filename: 'postclient.key'
+chainsmith_client_pkey_filename: 'postgresql.key'
 chainsmith_client_root_filename: root.crt
 
 chainsmith_internal_clients: "{% set clients = [] %}{% for groupclients in chainsmith_users.values() %}{% do clients.extend(groupclients) %}{% endfor %}{{ clients }}"


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

For some unknown reason, the name of the private key of the postgresql client cert was mis-named.
This causes stolon standby's not to start

## What is the new behavior?

- Naming is correct
- all works as expected again

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


