### PR TITLE
fix: kill Postgres when stolon-keeper dies

### DIFF
--- a/roles/stolon/templates/stolon-keeper.service.j2
+++ b/roles/stolon/templates/stolon-keeper.service.j2
@@ -20,7 +20,7 @@ Environment="{{ key }}={{ value }}"
 ExecStart=/usr/local/bin/stolon-keeper
 
 # only kill the stolon process, not it's children, so it will gracefully stop postgres. We need to test this.
-KillMode=process
+KillMode=control-group
 
 # Give a reasonable amount of time for the server to start up/shut down
 TimeoutSec=30


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Fixes #41: When stolon-keeper stops unexpectedly (like kill -9), postgres stays running while another instance is promoted

## What is the new behavior?

Fixes #41: When stolon-keeper stops unexpectedly (like kill -9), systemd also stops child processes (postgres)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
