### PR TITLE
feat: role versioning

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -6,7 +6,7 @@ collections:
 
 roles:
   - name: pgvillage.avchecker
-    version: "v0.1.0"
+    version: "v0.1.1"
   - name: pgvillage.chainsmith
     version: "v0.1.1"
   - name: pgvillage.etcd
@@ -18,7 +18,7 @@ roles:
   - name: pgvillage.keepalived
     version: "v0.1.0"
   - name: pgvillage.linux
-    version: "v0.1.1"
+    version: "v0.1.2"
   - name: pgvillage.minio
     version: "v0.1.1"
   - name: pgvillage.nagios
@@ -32,6 +32,6 @@ roles:
   - name: pgvillage.pgbouncer
     version: "v0.1.0"
   - name: pgvillage.stolon
-    version: "v0.1.2"
+    version: "v0.1.3"
   - name: pgvillage.walg
     version: "v0.1.0"

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,17 +6,32 @@ collections:
 
 roles:
   - name: pgvillage.avchecker
+    version: "v0.1.0"
   - name: pgvillage.chainsmith
+    version: "v0.1.1"
   - name: pgvillage.etcd
+    version: "v0.1.1"
   - name: pgvillage.firewall
+    version: "v0.1.0"
   - name: pgvillage.haproxy
+    version: "v0.1.0"
   - name: pgvillage.keepalived
+    version: "v0.1.0"
   - name: pgvillage.linux
+    version: "v0.1.1"
   - name: pgvillage.minio
+    version: "v0.1.1"
   - name: pgvillage.nagios
+    version: "v0.1.0"
   - name: pgvillage.pgfga
+    version: "v0.1.0"
   - name: pgvillage.pgquartz
+    version: "v0.1.0"
   - name: pgvillage.pgroute66
+    version: "v0.1.0"
   - name: pgvillage.pgbouncer
+    version: "v0.1.0"
   - name: pgvillage.stolon
+    version: "v0.1.2"
   - name: pgvillage.walg
+    version: "v0.1.0"


### PR DESCRIPTION
Added version specifications for ansible roles.

When installing roles from ansible galaxy, specific versions will be installed based on ./requirements.yml

This way,  we will have releases of pgvillage which are also based on role versions. Also, if pgvillage roles are updated, there is always a working version to go back to.